### PR TITLE
Feature/fix typo CVS/CSV

### DIFF
--- a/pbf_file_size_estimation/__init__.py
+++ b/pbf_file_size_estimation/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.7'
+__version__ = '1.0.0'
 default_app_config = 'pbf_file_size_estimation.apps.PBFFileSizeEstimationConfig'

--- a/pbf_file_size_estimation/app_settings.py
+++ b/pbf_file_size_estimation/app_settings.py
@@ -3,5 +3,5 @@ from django.conf import settings
 
 
 PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'planet-stats.csv')
-if hasattr(settings, 'PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH'):
-    PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH = settings.PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH
+if hasattr(settings, 'PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH'):
+    PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH = settings.PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH

--- a/pbf_file_size_estimation/app_settings.py
+++ b/pbf_file_size_estimation/app_settings.py
@@ -2,6 +2,6 @@ import os
 from django.conf import settings
 
 
-PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'planet-stats.csv')
+PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'planet-stats.csv')
 if hasattr(settings, 'PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH'):
-    PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH = settings.PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH
+    PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH = settings.PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH

--- a/pbf_file_size_estimation/serializers.py
+++ b/pbf_file_size_estimation/serializers.py
@@ -1,8 +1,8 @@
-from .app_settings import PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH
+from .app_settings import PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH
 from .estimate_size import estimate_size_of_extent
 from rest_framework import serializers
 
-csv_source_file = PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH
+csv_source_file = PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH
 
 
 class FileEstimationSerializer(serializers.Serializer):

--- a/tests/file_size_estimation/estimate_size_test.py
+++ b/tests/file_size_estimation/estimate_size_test.py
@@ -1,11 +1,11 @@
 from django.test import TestCase
 
-from pbf_file_size_estimation.app_settings import PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH
+from pbf_file_size_estimation.app_settings import PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH
 from pbf_file_size_estimation.estimate_size import estimate_size_of_extent, OutOfBoundsError
 
 
 class EstimateSizeTest(TestCase):
-    csv_file_name = PBF_FILE_SIZE_ESTIMATION_CVS_FILE_PATH
+    csv_file_name = PBF_FILE_SIZE_ESTIMATION_CSV_FILE_PATH
 
     def test_monaco_size_estimation(self):
         monaco_bbox = [7.400, 43.717, 7.439, 43.746]


### PR DESCRIPTION
This is about character-separated values, not the Concurrent Versions System.
### Reviewed by
- [x] @hixi 
